### PR TITLE
feat: support download as svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       www.google-analytics.com
       www.googletagmanager.com
       www.gravatar.com
+      blob:
       " />
 
     <meta name="description" content="Graph / visualize of npm dependencies" />
@@ -43,6 +44,7 @@
       <button id="zoomWidthButton" title="fit width" class="material-icons">swap_horiz</button>
       <button id="zoomDefaultButton" title="1x" class="material-icons">search</button>
       <button id="zoomHeightButton" title="fit height" class="material-icons">swap_vert</button>
+      <button id="downloadButton" title="download" class="material-icons">cloud_download</button>
     </div>
 
     <div id="inspector">

--- a/js/index.js
+++ b/js/index.js
@@ -65,6 +65,55 @@ function zoom(op) {
   }
 }
 
+function download(type) {
+  switch (type) {
+    case 'svg':
+      downloadSvg();
+      break;
+    case 'png':
+      downloadPng();
+      break;
+  }
+}
+
+function downloadPng() {
+  const svg = $('svg');
+  const data = $('svg').outerHTML;
+  const vb = svg.getAttribute('viewBox').split(' ');
+
+  const canvas = document.createElement('canvas');
+  canvas.width = vb[2];
+  canvas.height = vb[3];
+  const ctx = canvas.getContext('2d');
+  const DOMURL = window.URL || window.webkitURL || window;
+  const img = new Image();
+  const svgBlob = new Blob([data], {type: 'image/svg+xml'});
+  const url = DOMURL.createObjectURL(svgBlob);
+  img.onload = function() {
+    ctx.drawImage(img, 0, 0);
+    DOMURL.revokeObjectURL(url);
+    const pngImg = canvas.toDataURL('image/png');
+    generateLinkToDownload('download.png', pngImg);
+  };
+  img.src = url;
+}
+
+function downloadSvg() {
+  const svgData = $('svg').outerHTML;
+  const svgBlob = new Blob([svgData], {type: 'image/svg+xml;charset=utf-8'});
+  const svgUrl = URL.createObjectURL(svgBlob);
+  generateLinkToDownload('download.svg', svgUrl);
+}
+
+function generateLinkToDownload(name, link) {
+  const downloadLink = document.createElement('a');
+  downloadLink.href = link;
+  downloadLink.download = name;
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+}
+
 async function graph(module) {
   Inspector.toggle(false);
 
@@ -234,6 +283,7 @@ onload = function() {
   $('#zoomWidthButton').onclick = () => zoom(1);
   $('#zoomDefaultButton').onclick = () => zoom(0);
   $('#zoomHeightButton').onclick = () => zoom(2);
+  $('#downloadButton').onclick = () => download('svg');
 
   Store.init();
   Inspector.init();


### PR DESCRIPTION
I added a button to support download as svg.

<img src="https://raw.githubusercontent.com/brizer/graph-bed/master/img/20190916163633.png"/>

At the same time, the processing method reserved for the png.