### PR TITLE
Feature: add file picker as an upload option

### DIFF
--- a/index.css
+++ b/index.css
@@ -231,6 +231,7 @@ g .stub > path {
   background-color: #ddd;
   border: dashed 2px #888;
   padding: 1em;
+  cursor: pointer;
 }
 #drop_target.drag {
 	background-color: #ccf;

--- a/index.html
+++ b/index.html
@@ -91,23 +91,9 @@
         <p>
         Enter NPM module name here <i class="material-icons">arrow_upward</i> to see the dependency graph.  To graph multiple modules separate names with commas (e.g. <a href="?q=mocha, chalk, rimraf">"mocha, chalk, rimraf"</a>).
         </p>
-        <br/>
         <div id="drop_target" style="text-align: center">
-					... drop a <code>package.json</code> file here
+          ... or drop a <code>package.json</code> file here
         </div>
-        <br/>
-        <p>
-          <div style="text-align: center;">
-            ... or upload a <code>package.json</code> file here
-            <p>
-              <form id="upload_file" style="text-align: center;">
-                <input type="file" name="file" />
-                <input type="submit" value="Done" />
-              </form>
-            </p>
-          </div>
-          
-        </p>
         <div id="info-footer">
           <div id="copyright">
             &copy; Robert Kieffer, 2017  MIT License

--- a/index.html
+++ b/index.html
@@ -91,9 +91,23 @@
         <p>
         Enter NPM module name here <i class="material-icons">arrow_upward</i> to see the dependency graph.  To graph multiple modules separate names with commas (e.g. <a href="?q=mocha, chalk, rimraf">"mocha, chalk, rimraf"</a>).
         </p>
+        <br/>
         <div id="drop_target" style="text-align: center">
-					... or drop a <code>package.json</code> file here
-				</div>
+					... drop a <code>package.json</code> file here
+        </div>
+        <br/>
+        <p>
+          <div style="text-align: center;">
+            ... or upload a <code>package.json</code> file here
+            <p>
+              <form id="upload_file" style="text-align: center;">
+                <input type="file" name="file" />
+                <input type="submit" value="Done" />
+              </form>
+            </p>
+          </div>
+          
+        </p>
         <div id="info-footer">
           <div id="copyright">
             &copy; Robert Kieffer, 2017  MIT License

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
         <div id="drop_target" style="text-align: center">
           ... or drop a <code>package.json</code> file here
         </div>
+        <input id="file_upload" type="file" accept="application/json" style="position: fixed; top: -100em" />
         <div id="info-footer">
           <div id="copyright">
             &copy; Robert Kieffer, 2017  MIT License

--- a/js/index.js
+++ b/js/index.js
@@ -239,6 +239,38 @@ onload = function() {
   Inspector.init();
   Inspector.showPane('pane-info');
 
+  /** Loads a `File` object as a package.json. */
+  async function loadPackageJSON(file) {
+    if (file.type && file.type != 'application/json') return alert('File must have a ".json" extension');
+    if (!file) return alert('Please drop a file, not... well... whatever else it was you dropped');
+
+    const reader = new FileReader();
+
+    const content = await new Promise((resolve, reject) => {
+      reader.onload = () => resolve(reader.result);
+      reader.readAsText(file);
+    });
+
+    const module = new Module(JSON.parse(content));
+    history.pushState({module}, null, `${location.pathname}?upload=${file.name}`);
+    graph(module);
+  }
+
+  // Handle file chooser submit
+  const uploadFileRef = $('#upload_file');
+  Object.assign(uploadFileRef, {
+    onsubmit: async ev => {
+      ev.preventDefault();
+
+      // get file from upload `input`
+      const formData = new FormData(uploadFileRef);
+      const file = formData.get('file');
+      if (!file) return alert('No files found in file upload');
+
+      return loadPackageJSON(file);
+    }
+  });
+
   // Handle file drops
   Object.assign($('#drop_target'), {
     ondrop: async ev => {
@@ -251,21 +283,9 @@ onload = function() {
       if (dt.items.length != 1) return alert('You must drop exactly one file');
 
       const item = dt.items[0];
-      if (item.type && item.type != 'application/json') return alert('File must have a ".json" extension');
-
       const file = item.getAsFile();
-      if (!file) return alert('Please drop a file, not... well... whatever else it was you dropped');
 
-      const reader = new FileReader();
-
-      const content = await new Promise((resolve, reject) => {
-        reader.onload = () => resolve(reader.result);
-        reader.readAsText(file);
-      });
-
-      const module = new Module(JSON.parse(content));
-      history.pushState({module}, null, `${location.pathname}?upload=${file.name}`);
-      graph(module);
+      return loadPackageJSON(file);
     },
 
     ondragover: ev => {

--- a/js/index.js
+++ b/js/index.js
@@ -256,8 +256,27 @@ onload = function() {
   Inspector.init();
   Inspector.showPane('pane-info');
 
+
+  // Handle file upload
+  $('#file_upload').onchange = async changeEv => {
+    changeEv.preventDefault();
+
+    const files = changeEv.target.files;
+    if (!files || files.length !== 1) {
+      return;
+    }
+
+    return graphPackageJSON(files[0]);
+  };
+
   // Handle file drops
   Object.assign($('#drop_target'), {
+    onclick: ev => {
+      ev.preventDefault();
+      // trigger file dialog using dummy element
+      $('#file_upload').click();
+    },
+
     ondrop: async ev => {
       ev.target.classList.remove('drag');
       ev.preventDefault();
@@ -281,26 +300,6 @@ onload = function() {
     ondragleave: ev => {
       ev.currentTarget.classList.remove('drag');
       ev.preventDefault();
-    },
-    onclick: ev => {
-      ev.preventDefault();
-
-      // trigger file dialog using dummy element
-      const inputElt = document.createElement('input');
-      inputElt.setAttribute('type', 'file');
-      inputElt.setAttribute('accept', 'application/json');
-
-      inputElt.onchange = async changeEv => {
-        changeEv.preventDefault();
-
-        const files = changeEv.target.files;
-        if (!files || files.length !== 1) {
-          return alert('Something went wrong');
-        }
-
-        return graphPackageJSON(files[0]);
-      };
-      inputElt.click();
     }
   });
 

--- a/js/index.js
+++ b/js/index.js
@@ -294,8 +294,9 @@ onload = function() {
         changeEv.preventDefault();
 
         const files = changeEv.target.files;
-        if (!files) return;
-        if (files.length !== 1) return;
+        if (!files || files.length !== 1) {
+          return alert('Something went wrong');
+        }
 
         return graphPackageJSON(files[0]);
       };


### PR DESCRIPTION
### Changes
- add file-picker alongside drag-to-upload box

### Comments
I usually fullscreen Chrome on Mac, so the lack of a file picker option to upload my `package.json` caused bad UX for me. Currently, in order to upload my package.json, I had to
1. un-fullscreen chrome,
2. find the file using Finder,
3. drag it into the application
4. and then re-fullscreen chrome.

I like the idea of the drag box, but I think it would be better UX to also give users the option to use the browser's picker.

### Testing
I hand-tested that the drag-box and the new upload prompt worked on the latest versions of Chrome (Mac), Safari (Mac), Firefox (Ubuntu 18.04), and Edge (Windows 10).

### Screenshots
#### New Upload View
<img width="480" alt="Screen Shot 2020-02-05 at 12 33 02 PM" src="https://user-images.githubusercontent.com/25801341/73866925-b49d2f00-4813-11ea-824e-e437159eccab.png">

#### Current Upload View (for comparison)
<img width="480" alt="Screen Shot 2020-02-05 at 12 33 09 PM" src="https://user-images.githubusercontent.com/25801341/73866934-b6ff8900-4813-11ea-95d9-2206b8520eee.png">
