### PR TITLE
Avoid shrinking tabs on large dependency trees

### DIFF
--- a/index.css
+++ b/index.css
@@ -193,6 +193,7 @@ summary {
 
 #tabs {
   flex-basis: auto;
+  flex-shrink: 0;
   margin-left: var(--rad_lg);
   display: flex;
   user-select: none;


### PR DESCRIPTION
![gif](https://user-images.githubusercontent.com/1402241/103706958-6472a380-4f73-11eb-9194-2a0a99224205.gif)


1. Visit http://npm.broofa.com/?q=webpack
2. Resize the window vertically
3. Notice the tabs getting squished