### PR TITLE
Escape module name in loader

### DIFF
--- a/js/Store.js
+++ b/js/Store.js
@@ -92,7 +92,7 @@ class Store {
       // Also, we can't fetch scoped modules at specific versions.  See https://goo.gl/dSMitm
       const reqPath = !isScoped && versionIsValid ? pathAndVersion : path;
 
-      const finish = this.activity.start(`Fetching ${reqPath}`);
+      const finish = this.activity.start(`Fetching ${decodeURIComponent(reqPath)}`);
       req = this.requestCache[reqPath] = fetchJSON(`https://registry.npmjs.cf/${reqPath}`)
         // Errors get turned into stub modules, below
         .catch(err => err)


### PR DESCRIPTION
Namespaced package names need to be escaped, notice the `%2F`:

## Before

![gif](https://user-images.githubusercontent.com/1402241/110745102-66214780-8200-11eb-996d-7fd77acda97c.gif)

## After

![2gif](https://user-images.githubusercontent.com/1402241/110745107-67527480-8200-11eb-9548-521ecb73e158.gif)
