### PR TITLE
Don't make the module name bolder on selection

### DIFF
--- a/css/Graph.scss
+++ b/css/Graph.scss
@@ -68,7 +68,6 @@ g.node {
 
   &.selected > text {
     fill: black;
-    font-weight: 600;
   }
 
   &.warning > path {


### PR DESCRIPTION
Bold text changes width and overflows its container

<img width="151" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/138587147-41f28f0e-a0b0-4cde-adba-49c04e200b10.png">
But the orange border should be enough as a highlight



<img width="154" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/138587141-9365f72c-a40f-4d3d-be35-41b059878125.png">