### PR TITLE
Fix the size of zoom buttons

### DIFF
--- a/css/Graph.scss
+++ b/css/Graph.scss
@@ -19,8 +19,6 @@
     display: inline-block;
     font-size: 1.8em;
     line-height: 1em;
-    width: 1.3em;
-    padding: 0;
     margin: 0;
     color: var(--text);
     border: solid 1px var(--bg1);


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/439401/139069337-9a598e19-da3b-4eaf-8973-741e99d08472.png)

After:
![image](https://user-images.githubusercontent.com/439401/139069435-1f1b4c40-926e-4117-9c5f-b78cc3a60cbc.png)

The `1:1` button has some padding applied using inline styles, which broke the fixed width set to `1.3em`.
An alternative fix is to apply `box-sizing: content-box` so that the width of `1.3em` does not contain the padding.  But this is less robust as it still depends on the font being applied (for instance, forcing a monospace font would need `3em` to write `1:1` without overflowing). Letting the browser compute the necessary size during layout is better to me.