### PR TITLE
fix: fix broken repo links

### DIFF
--- a/components/InfoPane/RegistryInput.tsx
+++ b/components/InfoPane/RegistryInput.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { DEFAULT_NPM_REGISTRY } from '../../lib/constants.ts';
 import useRegistry from '../../lib/useRegistry.ts';
-import styles from './RegistryInput.module.scss';
+import * as styles from './RegistryInput.module.scss';
 
 enum RegistryStatus {
   PENDING = 'pending',

--- a/lib/repo_util.test.ts
+++ b/lib/repo_util.test.ts
@@ -108,6 +108,34 @@ describe('getRepoUrlForModule', () => {
     assert.equal(result, 'https://github.com/user/repo');
   });
 
+  it('should handle http GitHub repository URLs with .git suffix', () => {
+    const module = new Module({
+      name: 'test',
+      version: '1.0.0',
+      repository: {
+        type: 'git',
+        url: 'http://github.com/drewyoung1/armyjs.git',
+      },
+    } as PackumentVersion);
+
+    const result = getRepoUrlForModule(module);
+    assert.equal(result, 'https://github.com/drewyoung1/armyjs');
+  });
+
+  it('should handle https GitHub repository URLs with .git suffix', () => {
+    const module = new Module({
+      name: 'test',
+      version: '1.0.0',
+      repository: {
+        type: 'git',
+        url: 'https://github.com/uuidjs/uuid.git',
+      },
+    } as PackumentVersion);
+
+    const result = getRepoUrlForModule(module);
+    assert.equal(result, 'https://github.com/uuidjs/uuid');
+  });
+
   it('should handle Bitbucket repositories', () => {
     const module = new Module({
       name: 'test',

--- a/lib/repo_util.ts
+++ b/lib/repo_util.ts
@@ -1,6 +1,12 @@
 import hostedGitInfo from 'hosted-git-info';
 import type Module from './Module.ts';
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import urlPolyfill from 'url';
+
+// @ts-expect-error - workaround https://github.com/npm/hosted-git-info/issues/330
+urlPolyfill.URL = globalThis.URL;
+
 /**
  * Extracts and normalizes repository URL from a module's package.json metadata.
  *


### PR DESCRIPTION
`hosted-git-info` expects node's native `url` module, but breaks with the 3rd party polyfill that `parcel` auto-injects (why, god, why???)  The fix is to manually set `url.URL` to the global `URL`.

<img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWNwZWxuOXN2NjQ2Ynh0b2o2a2c1NG16ODB0a3d0ZThyeWp0YXN0MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IlfbS49kOofMgl9kRR/giphy.gif" width="400" />