### PR TITLE
fix: intro logo size

### DIFF
--- a/components/Intro.module.scss
+++ b/components/Intro.module.scss
@@ -16,7 +16,7 @@
     background: radial-gradient(var(--bg0), var(--bg-root));
   }
 
-  h1  svg {
+  h1 svg {
     display: block;
     margin: auto;
     max-width: 90%;
@@ -39,5 +39,4 @@
   ul {
     margin: 0;
   }
-
 }

--- a/components/Intro.module.scss
+++ b/components/Intro.module.scss
@@ -16,10 +16,10 @@
     background: radial-gradient(var(--bg0), var(--bg-root));
   }
 
-  h1 {
-    margin-block: 0;
-    font-size: 4em;
-    font-family: Monaco, monospace;
+  h1  svg {
+    display: block;
+    margin: auto;
+    max-width: 90%;
   }
 
   h2 {
@@ -39,4 +39,5 @@
   ul {
     margin: 0;
   }
+
 }

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -2,7 +2,7 @@ import RawLogo from 'jsx:../images/logo.svg';
 import * as styles from './Logo.module.scss';
 
 function Logo() {
-  return <RawLogo className={styles.root} />;
+  return <RawLogo viewBox="0 0 545.7 100" className={styles.root} />;
 }
 
 export default Logo;


### PR DESCRIPTION
<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td valign=top><img width="830" height="1098" alt="Screen Shot 2026-05-05 at 15 39 06" src="https://github.com/user-attachments/assets/4fec7bd5-cd6b-4ffb-b5b8-82529691d148" />
	<td valign=top><img width="860" height="1098" alt="after" src="https://github.com/user-attachments/assets/34f3a6b4-0831-4880-a6d4-c6be6fbcdfc4" />
</table>