### PR TITLE
fix: don't auto-install commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "scripts": {
     "build": "parcel build index.html robots.txt --no-cache",
     "fetch-licenses": "node scripts/fetch_licenses.js",
-    "prepare": "lefthook install",
     "release": "standard-version",
     "start": "parcel serve index.html robots.txt --no-cache",
     "lint": "eslint .",


### PR DESCRIPTION
CI already exists to enforce conventions. `npx lefthook install` can still be run manually for those interested in pre-commit hooks rather than forcing them to use them. `git commit` is the same as `Save file` and saving files should not be blocked.